### PR TITLE
Enable D8 Core rest module, endpoints for /user https://trello.com/c/…

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -30,6 +30,8 @@ module:
   path: 0
   quickedit: 0
   rdf: 0
+  rest: 0
+  serialization: 0
   shortcut: 0
   system: 0
   taxonomy: 0

--- a/config/sync/rest.settings.yml
+++ b/config/sync/rest.settings.yml
@@ -1,0 +1,50 @@
+resources:
+  'entity:node':
+    GET:
+      supported_formats:
+        - hal_json
+      supported_auth:
+        - basic_auth
+    POST:
+      supported_formats:
+        - hal_json
+      supported_auth:
+        - basic_auth
+    PATCH:
+      supported_formats:
+        - hal_json
+      supported_auth:
+        - basic_auth
+    DELETE:
+      supported_formats:
+        - hal_json
+      supported_auth:
+        - basic_auth
+  'entity:user':
+    GET:
+      supported_formats:
+        - json
+        - xml
+      supported_auth:
+        - cookie
+    POST:
+      supported_formats:
+        - json
+        - xml
+      supported_auth:
+        - cookie
+    DELETE:
+      supported_formats:
+        - json
+        - xml
+      supported_auth:
+        - cookie
+    PATCH:
+      supported_formats:
+        - json
+        - xml
+      supported_auth:
+        - cookie
+link_domain: null
+_core:
+  default_config_hash: E9VXRiWZNet4YVBv8j9WQmTlgb-rOjo0MiCSdgV0Guw


### PR DESCRIPTION
Enable D8 Core rest module, endpoints for /user https://trello.com/c/csFtKUUS/19-integrate-angular

endpoints: 
- /api/leaderboard?_format=json and
- /user/[uid]?_format=json

more docs:
- Example endpoints: https://www.drupal.org/documentation/modules/rest/javascript. WARNING: Many of these changed (?_format=json was added in beta12 apparently). See next bullet for more details:
- http://www.darrylnorris.com/blog/how-to-request-a-node-via-rest-using-web-services-drupal-8
